### PR TITLE
basic support for events

### DIFF
--- a/github_to_sqlite/cli.py
+++ b/github_to_sqlite/cli.py
@@ -405,6 +405,31 @@ def contributors(db_path, repos, auth):
     type=click.Path(file_okay=True, dir_okay=False, allow_dash=False),
     required=True,
 )
+@click.argument("namespaces", type=str, nargs=-1)
+@click.option(
+    "-a",
+    "--auth",
+    type=click.Path(file_okay=True, dir_okay=False, allow_dash=True),
+    default="auth.json",
+    help="Path to auth.json token file",
+)
+def events(db_path, namespaces, auth):
+    "Save events for the specified namespaces"
+    db = sqlite_utils.Database(db_path)
+    token = load_token(auth)
+    for ns in namespaces:
+        events = utils.fetch_events(ns, token)
+        utils.save_events(db, events, ns)
+        time.sleep(1)
+    utils.ensure_db_shape(db)
+
+
+@cli.command()
+@click.argument(
+    "db_path",
+    type=click.Path(file_okay=True, dir_okay=False, allow_dash=False),
+    required=True,
+)
 @click.argument("repos", type=str, nargs=-1)
 @click.option(
     "--all",


### PR DESCRIPTION
a quick first pass at implementing the feature requested in https://github.com/dogsheep/github-to-sqlite/issues/64

testing instructions:

```
$ github-to-sqlite events events.db users/khimaros
```

if the specified user is the authenticated user, it will also include private events.

caveat: pagination appears to be broken (i don't see `next` in the response JSON from GitHub)