### PR TITLE
Replacing step ID key with step_id

### DIFF
--- a/github_to_sqlite/utils.py
+++ b/github_to_sqlite/utils.py
@@ -845,6 +845,10 @@ def save_workflow(db, repo_id, filename, content):
     db["workflows"].create_index(["repo", "filename"], unique=True, if_not_exists=True)
     for job_name, job_details in jobs.items():
         steps = job_details.pop("steps", None) or []
+        # Removing ID from step and adding step_id
+        for i, step in enumerate(steps):
+            if 'id' in steps[i]:
+                steps[i]['step_id'] = steps[i].pop('id')
         job_id = (
             db["jobs"]
             .insert(


### PR DESCRIPTION
Workflows that have an `id` in any step result in the following error when running `workflows`:

e.g.`github-to-sqlite workflows github.db nixos/nixpkgs`

```Traceback (most recent call last):
  File "/usr/local/bin/github-to-sqlite", line 8, in <module>
    sys.exit(cli())
  File "/usr/local/lib/python3.8/dist-packages/click/core.py", line 1137, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.8/dist-packages/click/core.py", line 1062, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.8/dist-packages/click/core.py", line 1668, in invoke```Traceback (most recent call last):
  File "/usr/local/bin/github-to-sqlite", line 8, in <module>
    sys.exit(cli())
  File "/usr/local/lib/python3.8/dist-packages/click/core.py", line 1137, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.8/dist-packages/click/core.py", line 1062, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.8/dist-packages/click/core.py", line 1668, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.8/dist-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.8/dist-packages/click/core.py", line 763, in invoke
    return __callback(*args, **kwargs)
  File "/usr/local/lib/python3.8/dist-packages/github_to_sqlite/cli.py", line 601, in workflows
    utils.save_workflow(db, repo_id, filename, content)
  File "/usr/local/lib/python3.8/dist-packages/github_to_sqlite/utils.py", line 865, in save_workflow
    db["steps"].insert_all(
  File "/usr/local/lib/python3.8/dist-packages/sqlite_utils/db.py", line 2596, in insert_all
    self.insert_chunk(
  File "/usr/local/lib/python3.8/dist-packages/sqlite_utils/db.py", line 2378, in insert_chunk
    result = self.db.execute(query, params)
  File "/usr/local/lib/python3.8/dist-packages/sqlite_utils/db.py", line 419, in execute
    return self.conn.execute(sql, parameters)
sqlite3.IntegrityError: datatype mismatch
```

 - [Information about the ID key in a step for GHA](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstepsid)
 - [An example workflow from a public repo](https://github.com/NixOS/nixpkgs/blob/b4cc66827745e525ce7bb54659845ac89788a597/.github/workflows/direct-push.yml#L16)

# Changes
I'm proposing that the key for `id` in step is replaced with `step_id` so that it no longer interferes with the table `id` for tracking the record.

Special thanks to @sarcasticadmin @egiffen and @ruebenramirez for helping a bit on this 😄 