### PR TITLE
Fixing 'NoneType' object has no attribute 'items'

### DIFF
--- a/github_to_sqlite/utils.py
+++ b/github_to_sqlite/utils.py
@@ -223,6 +223,11 @@ def save_pull_requests(db, pull_requests, repo):
 
 
 def save_user(db, user):
+    # Under some conditions, GitHub caches removed repositories with  
+    # stars and ends up leaving dangling `None` user references.
+    if user is None:
+        return None
+    
     # Remove all url fields except avatar_url and html_url
     to_save = {
         key: value


### PR DESCRIPTION
Under some conditions, GitHub caches removed starred repositories and ends up leaving dangling `None` user references.

    Traceback (most recent call last):
      File "/home/dogsheep/dogsheep/github-to-sqlite/bin/github-to-sqlite", line 8, in <module>
        sys.exit(cli())
      File "/home/dogsheep/dogsheep/github-to-sqlite/lib64/python3.10/site-packages/click/core.py", line 1130, in __call__
        return self.main(*args, **kwargs)
      File "/home/dogsheep/dogsheep/github-to-sqlite/lib64/python3.10/site-packages/click/core.py", line 1055, in main
        rv = self.invoke(ctx)
      File "/home/dogsheep/dogsheep/github-to-sqlite/lib64/python3.10/site-packages/click/core.py", line 1657, in invoke
        return _process_result(sub_ctx.command.invoke(sub_ctx))
      File "/home/dogsheep/dogsheep/github-to-sqlite/lib64/python3.10/site-packages/click/core.py", line 1404, in invoke
        return ctx.invoke(self.callback, **ctx.params)
      File "/home/dogsheep/dogsheep/github-to-sqlite/lib64/python3.10/site-packages/click/core.py", line 760, in invoke
        return __callback(*args, **kwargs)
      File "/home/dogsheep/dogsheep/github-to-sqlite/lib64/python3.10/site-packages/github_to_sqlite/cli.py", line 181, in starred
        utils.save_stars(db, user, stars)
      File "/home/dogsheep/dogsheep/github-to-sqlite/lib64/python3.10/site-packages/github_to_sqlite/utils.py", line 494, in save_stars
        repo_id = save_repo(db, repo)
      File "/home/dogsheep/dogsheep/github-to-sqlite/lib64/python3.10/site-packages/github_to_sqlite/utils.py", line 308, in save_repo
        to_save["owner"] = save_user(db, to_save["owner"])
      File "/home/dogsheep/dogsheep/github-to-sqlite/lib64/python3.10/site-packages/github_to_sqlite/utils.py", line 229, in save_user
        for key, value in user.items()
    AttributeError: 'NoneType' object has no attribute 'items'