### PR TITLE
Add organization support to repos command

### DIFF
--- a/github_to_sqlite/cli.py
+++ b/github_to_sqlite/cli.py
@@ -243,7 +243,12 @@ def stargazers(db_path, repos, auth):
     is_flag=True,
     help="Fetch HTML rendered README into 'readme_html' column",
 )
-def repos(db_path, usernames, auth, repo, load, readme, readme_html):
+@click.option(
+    "--organization",
+    is_flag=True,
+    help="The given users are organizations",
+)
+def repos(db_path, usernames, auth, repo, load, readme, readme_html, organization):
     "Save repos owned by the specified (or authenticated) username or organization"
     db = sqlite_utils.Database(db_path)
     token = load_token(auth)
@@ -260,7 +265,7 @@ def repos(db_path, usernames, auth, repo, load, readme, readme_html):
             if not usernames:
                 usernames = [None]
             for username in usernames:
-                for repo in utils.fetch_all_repos(username, token):
+                for repo in utils.fetch_all_repos(username, token, organization):
                     repo_id = utils.save_repo(db, repo)
                     _repo_readme(
                         db, token, repo_id, repo["full_name"], readme, readme_html

--- a/github_to_sqlite/utils.py
+++ b/github_to_sqlite/utils.py
@@ -444,15 +444,19 @@ def fetch_stargazers(repo, token=None):
         yield from stargazers
 
 
-def fetch_all_repos(username=None, token=None):
+def fetch_all_repos(username=None, token=None, organization=False):
     assert username or token, "Must provide username= or token= or both"
     headers = make_headers(token)
     # Get topics for each repo:
     headers["Accept"] = "application/vnd.github.mercy-preview+json"
     if username:
         url = "https://api.github.com/users/{}/repos".format(username)
+        if organization:
+            url = "https://api.github.com/orgs/{}/repos".format(username)
     else:
         url = "https://api.github.com/user/repos"
+        if organization:
+            url = "https://api.github.com/orgs/{}/repos".format(username)
     for repos in paginate(url, headers):
         yield from repos
 


### PR DESCRIPTION
New --organization flag to signify all given "usernames" are private
orgs. Adapts API URL to the organization path instead.

Not the best implementation, but a first draft.

Fixes #75 (badly, no tests, overly vague)